### PR TITLE
Add a row of tiny icons to the index page to remind developers that they are often used at this size.

### DIFF
--- a/templates/index.html.lodash
+++ b/templates/index.html.lodash
@@ -19,9 +19,15 @@
         overflow: hidden;
       }
 
+      .tiny-icons {
+        text-align: center;
+      }
+
       .icons-list {
         padding-left: 0;
         list-style: none;
+        display: inline-block;
+        text-align: center;
       }
 
       .icons-list li a {
@@ -32,7 +38,7 @@
       .icons-list li {
         color: black;
         background-color: #f9f9f9;
-        float: left;
+        display: inline-block;
         padding: 5px;
         border: 1px solid #fff;
         text-align: center;
@@ -128,6 +134,13 @@
           </ol>
 
           <h1 class="text-center" id="icons-list">Cubing Icons List</h1>
+
+          <div class="tiny-icons">
+            <% _.each(_.sortBy(glyphs, 'name'), function(glyph) { %>
+              <span class="cubing-icon <%= glyph.name %>"></span>
+            <% }); %>
+          </div>
+
           <div class="icons">
             <ul class="icons-list">
               <% _.each(_.sortBy(glyphs, 'name'), function(glyph) { %>


### PR DESCRIPTION
It took a little bit of effort to get this to look good. Turns out our icons grid wasn't actually centered, but you couldn't really tell until there was something truly centered on top of it.

Screenshot:

![image](https://cloud.githubusercontent.com/assets/277474/22445007/4ac5dac8-e6fa-11e6-970f-3fe2591a91f5.png)
