### PR TITLE
Move vertical-align so it applies to regular sized icons as well.

### DIFF
--- a/templates/cubing-icons.css.lodash
+++ b/templates/cubing-icons.css.lodash
@@ -6,6 +6,10 @@
   font-style: normal;
 }
 
+.<%= className %> {
+  vertical-align: middle;
+}
+
 .<%= className %>:before {
   display: inline-block;
   font-family: "<%= fontName %>";
@@ -14,12 +18,12 @@
   line-height: 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  vertical-align: -15%;
 }
 
 .<%= className %>-lg {
   font-size: 1.3333333333333333em;
   line-height: 0.75em;
-  vertical-align: -15%;
 }
 .<%= className %>-2x { font-size: 2em; }
 .<%= className %>-3x { font-size: 3em; }


### PR DESCRIPTION
Before (http://cubing.github.io/icons/):

![image](https://cloud.githubusercontent.com/assets/277474/22819281/456cedda-ef26-11e6-9e15-cee500797a7f.png)

After (https://www.jflei.com/icons/):

![image](https://cloud.githubusercontent.com/assets/277474/22819270/3b59e046-ef26-11e6-9007-2456463524ae.png)
