### PR TITLE
    Add support for publishing to npm on `@cubing/icons`.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+# Courtesy of https://github.com/shinnn/gulp-gh-pages
+.publish
+
+# These get copied into the www directory, which is included. There's no need
+# for duplicates.
+svgs/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ We use the excellent [gulp-iconfont](https://www.npmjs.com/package/gulp-iconfont
 - Install [potrace](http://potrace.sourceforge.net/).
 - `npm run build` or `npm run watch` - Open `www/index.html` in your web browser.
 
-## Deploy to GitHub Pages
+## Releasing
+
+### Bump version and deploy to npmjs
+
+```
+npm version major|minor|patch -m "Upgrade to %s for reasons"
+```
+
+### (Optional, this is handled automatically) Deploy to GitHub Pages
 
 ```
 npm run deploy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cubing-icons",
-  "version": "1.0.0",
+  "name": "@cubing/icons",
+  "version": "1.0.2",
   "description": "Cubing Icons and Fonts",
   "dependencies": {},
   "devDependencies": {
@@ -27,12 +27,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cubing/icons.git"
+    "url": "git+https://github.com/cubing/icons.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/cubing/icons.git/issues"
   },
-  "homepage": "https://github.com/cubing/icons.git#readme"
+  "homepage": "https://github.com/cubing/icons.git#readme",
+  "main": "./www/css/cubing-icons.css"
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "gulp",
     "watch": "gulp watch",
-    "deploy": "gulp deploy"
+    "deploy": "gulp deploy",
+    "version": "npm run build",
+    "postversion": "git push --follow-tags git@github.com:cubing/icons.git HEAD:main"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes https://github.com/cubing/icons/issues/60.