### PR TITLE
Add an action to release pushed tags as GitHub releases.

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,33 @@
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  Publish:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Calculate release name
+        run: |
+          GITHUB_REF=${{ github.ref }}
+          RELEASE_NAME=${GITHUB_REF#"refs/tags/"}
+          echo "RELEASE_NAME=${RELEASE_NAME}" >> $GITHUB_ENV
+      # We'd use `github.event.head_commit.message`, but that includes the first line of the message. So we check out the code.
+      - name: Check out code for release body calculation using `git` itself
+        uses: actions/checkout@v3
+      - name: Calculate release body
+        run: git log --format=%b -n 1 HEAD >> /tmp/body-path.txt
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_NAME }}
+          body_path: /tmp/body-path.txt
+          draft: false
+          prerelease: false


### PR DESCRIPTION
This allows the latest release to show under the "Releases" section of the sidebar at https://github.com/cubing/icons

This matches the same action implementation used across other `github.com/cubing` projects.