### PR TITLE
Update Mirror Blocks BLD icon

### DIFF
--- a/svgs/unofficial/333_mirror_blocks.svg
+++ b/svgs/unofficial/333_mirror_blocks.svg
@@ -1,1 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" style="shape-rendering:geometricPrecision;text-rendering:geometricPrecision;image-rendering:optimizeQuality;fill-rule:evenodd;clip-rule:evenodd"><path d="M29.5 28.5h155v175h-155v-175Z" style="opacity:.993"/><path d="M229.5 28.5h117v175h-117v-175Z" style="opacity:.987"/><path d="M391.5 28.5h79v175h-79v-175Z" style="opacity:.974"/><path d="M29.5 248.5h155v117h-155v-117Z" style="opacity:.99"/><path d="M229.5 248.5h117v117h-117v-117Z" style="opacity:.984"/><path d="M391.5 248.5h79v117h-79v-117Z" style="opacity:.972"/><path d="M29.5 410.5h155v59h-155v-59Z" style="opacity:.982"/><path d="M229.5 410.5h117v59h-117v-59Z" style="opacity:.976"/><path d="M391.5 410.5h79v59h-79v-59Z" style="opacity:.963"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="500"
+   height="500"
+   style="shape-rendering:geometricPrecision;text-rendering:geometricPrecision;image-rendering:optimizeQuality;fill-rule:evenodd;clip-rule:evenodd"
+   version="1.1"
+   id="svg9"
+   sodipodi:docname="333_mirror_blocks.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs9" />
+  <sodipodi:namedview
+     id="namedview9"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.94058568"
+     inkscape:cx="115.88524"
+     inkscape:cy="402.94043"
+     inkscape:window-width="2558"
+     inkscape:window-height="1559"
+     inkscape:window-x="0"
+     inkscape:window-y="39"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg9" />
+  <path
+     d="M29.5 28.5h155v175h-155v-175Z"
+     style="opacity:1"
+     id="path1" />
+  <path
+     d="M229.5 28.5h117v175h-117v-175Z"
+     style="opacity:1"
+     id="path2" />
+  <path
+     d="M391.5 28.5h79v175h-79v-175Z"
+     style="opacity:1"
+     id="path3" />
+  <path
+     d="M29.5 248.5h155v117h-155v-117Z"
+     style="opacity:1"
+     id="path4" />
+  <path
+     d="M229.5 248.5h117v117h-117v-117Z"
+     style="opacity:1"
+     id="path5" />
+  <path
+     d="M391.5 248.5h79v117h-79v-117Z"
+     style="opacity:1"
+     id="path6" />
+  <path
+     d="M29.5 410.5h155v59h-155v-59Z"
+     style="opacity:1"
+     id="path7" />
+  <path
+     d="M229.5 410.5h117v59h-117v-59Z"
+     style="opacity:1"
+     id="path8" />
+  <path
+     d="M391.5 410.5h79v59h-79v-59Z"
+     style="opacity:1"
+     id="path9" />
+</svg>

--- a/svgs/unofficial/333_mirror_blocks_bld.svg
+++ b/svgs/unofficial/333_mirror_blocks_bld.svg
@@ -7,7 +7,7 @@
    version="1.1"
    id="svg9"
    sodipodi:docname="333_mirror_blocks_bld.svg"
-   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -23,9 +23,9 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="0.67527068"
-     inkscape:cx="229.53758"
-     inkscape:cy="232.49936"
+     inkscape:zoom="0.6341325"
+     inkscape:cx="206.58143"
+     inkscape:cy="230.23579"
      inkscape:window-width="2558"
      inkscape:window-height="1559"
      inkscape:window-x="0"
@@ -33,37 +33,19 @@
      inkscape:window-maximized="1"
      inkscape:current-layer="svg9" />
   <path
-     d="M 88.714128,58.718018 H 37.279707 V 195.88268 h 51.434421 z"
      fill="#000000"
-     id="path1"
-     style="stroke-width:0.88638" />
-  <path
-     d="M 232.36045,58.718018 H 129.48895 V 195.88268 h 102.8715 z"
-     fill="#000000"
-     id="path2"
-     style="stroke-width:0.88638" />
-  <path
-     d="M 88.714128,236.65616 H 37.279707 v 102.87061 h 51.434421 z"
-     fill="#000000"
-     id="path4"
-     style="stroke-width:0.88638" />
-  <path
-     d="m 232.36045,236.65616 h -102.8715 v 102.87061 h 102.8715 z"
-     fill="#000000"
-     id="path5"
-     style="stroke-width:0.88638" />
-  <path
-     d="M 88.714128,380.30026 H 37.279707 v 68.58189 h 51.434421 z"
-     fill="#000000"
-     id="path7"
-     style="stroke-width:0.88638" />
-  <path
-     d="m 232.36045,380.30026 h -102.8715 v 68.58189 h 102.8715 z"
-     fill="#000000"
-     id="path8"
-     style="stroke-width:0.88638" />
-  <path
-     fill="#000000"
-     d="m 446.69206,253.76221 c 4.929,-76.658 73.935,-190.163004 -58.733,-190.163004 -111.138,0 -118.596,96.192004 -118.596,190.163004 0,84.969 4.044,186.586 106.526,190.163 142.872,4.987 76.281,-104.974 70.803,-190.163 z"
+     d="m 430.334,253.76221 c 4.929,-76.658 73.935,-190.163004 -58.733,-190.163004 -111.138,0 -118.596,96.192004 -118.596,190.163004 0,84.969 4.044,186.586 106.526,190.163 142.872,4.987 76.281,-104.974 70.803,-190.163 z"
      id="path3" />
+  <path
+     d="M 58.948,57.699182 H 196.46415 V 212.95936 H 58.948 Z"
+     style="clip-rule:evenodd;opacity:1;fill:#000000;fill-rule:evenodd;stroke-width:0.887201;image-rendering:optimizeQuality;shape-rendering:geometricPrecision;text-rendering:geometricPrecision"
+     id="path1-5" />
+  <path
+     d="M 58.948,252.8834 H 196.46415 V 356.68592 H 58.948 Z"
+     style="clip-rule:evenodd;opacity:1;fill:#000000;fill-rule:evenodd;stroke-width:0.887201;image-rendering:optimizeQuality;shape-rendering:geometricPrecision;text-rendering:geometricPrecision"
+     id="path4-3" />
+  <path
+     d="m 58.948,396.60996 h 137.51615 v 52.34486 H 58.948 Z"
+     style="clip-rule:evenodd;display:inline;opacity:1;fill:#000000;fill-rule:evenodd;stroke-width:0.887201;image-rendering:optimizeQuality;shape-rendering:geometricPrecision;text-rendering:geometricPrecision"
+     id="path7-5" />
 </svg>


### PR DESCRIPTION
The mirror blocks icon was updated recently, so I thought I'd update the blindfolded icon accordingly. The mirror blocks icon wasn't changed, I just fixed the opacity, all of the layers had ~98% opacity for some reason. Output images:

![333_mirror_blocks_bld](https://github.com/cubing/icons/assets/53250435/defe2d46-9aab-49d8-a7c9-fa7d95f4c958)

![333_mirror_blocks](https://github.com/cubing/icons/assets/53250435/3941748c-7070-44b5-9856-d568ac5e73bd)
