### PR TITLE
Add Linear FMC icon

### DIFF
--- a/svgs/unofficial/333_linear_fm.svg
+++ b/svgs/unofficial/333_linear_fm.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="500px"
+   height="500px"
+   viewBox="0 0 500 500"
+   enable-background="new 0 0 500 500"
+   xml:space="preserve"
+   sodipodi:docname="333_linear_fm.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs5" /><sodipodi:namedview
+   id="namedview5"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="0.7145443"
+   inkscape:cx="153.94427"
+   inkscape:cy="446.43838"
+   inkscape:window-width="2558"
+   inkscape:window-height="1559"
+   inkscape:window-x="0"
+   inkscape:window-y="39"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#000000"
+   d="m 64.16101,466.013 c -0.836,-1.796 -1.426,-3.058 -2.015,-4.322 -10.146,-21.757 -20.293,-43.514 -30.436,-65.271 -1.477,-3.171 0.235,-13.635 2.837,-15.838 0.808,-0.685 2.329,-0.77 3.512,-0.734 37.824,1.162 71.613,13.455 101.417,36.785 2.047,1.602 2.333,2.969 1.693,5.562 -1.72,6.972 -5.656,10.951 -12.381,13.901 -21.527,9.446 -42.704,19.694 -64.627,29.917 z"
+   id="path3"
+   inkscape:label="pencil tip" /><path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#000000"
+   d="m 46.34101,349.13 c 28.964,-79.663 57.749,-158.833 86.686,-238.421 39.981,0.633 75.703,13.602 106.74,38.845 -28.854,79.365 -57.585,158.397 -86.531,238.013 -32.38,-21.474 -68.053,-34.377 -106.895,-38.437 z"
+   id="path1"
+   inkscape:label="pencil" />
+<path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#000000"
+   d="M -6.6312107,403.89821 C 38.197124,280.60172 82.748416,158.06826 127.53496,34.887844 189.4146,35.867553 244.70246,55.940011 292.73923,95.009263 248.08114,217.84453 203.61344,340.1644 158.81295,463.38816 108.69759,430.15229 53.485561,410.18198 -6.6312107,403.89821 Z"
+   id="path7"
+   inkscape:label="pencil outline clip original"
+   style="display:none;stroke-width:1.54772" /><path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#000000"
+   d="m 143.52901,80.083 c 4.42,-12.027 8.563,-23.458 12.878,-34.826 0.492,-1.296 1.739,-2.749 2.988,-3.244 13.553,-5.377 27.471,-9.129 42.2,-9.437 20.949,-0.437 35.875,10.381 48.05,25.878 5.233,6.663 9.434,14.146 13.986,21.33 0.604,0.951 1.014,2.52 0.665,3.501 -4.166,11.724 -8.492,23.391 -12.912,35.446 -32.797,-21.733 -68.405,-34.528 -107.855,-38.648 z"
+   id="path2"
+   inkscape:label="pencil top" />
+
+
+
+
+<path
+   id="rect5"
+   style="fill:#000000;stroke-width:0;stroke-linejoin:round;paint-order:stroke fill markers"
+   d="M 248.11133 217.75977 C 235.49322 252.46772 222.84029 287.27254 210.21289 322.00586 L 366.02148 322.00586 L 366.02148 217.75977 L 248.11133 217.75977 z " /><path
+   sodipodi:type="star"
+   style="fill:#000000;stroke-width:0;stroke-linejoin:round;paint-order:stroke fill markers"
+   id="path6"
+   inkscape:flatsided="true"
+   sodipodi:sides="3"
+   sodipodi:cx="412.36371"
+   sodipodi:cy="264.01022"
+   sodipodi:r1="192.76398"
+   sodipodi:r2="96.381989"
+   sodipodi:arg1="2.0943951"
+   sodipodi:arg2="3.1415927"
+   inkscape:rounded="0"
+   inkscape:randomized="0"
+   d="m 315.98172,430.94872 0,-333.876997 289.14597,166.938497 z"
+   inkscape:transform-center-x="-25.959245"
+   transform="matrix(0.53867409,0,0,0.83470678,149.77056,47.628876)" /></svg>


### PR DESCRIPTION
This is a new event @lgarron started organizing and we will be holding it at Euros this year. The idea is that you just do one attempt at solving a 3x3 with as few moves as possible, and you can't backtrack (hence the arrow). Output image:

![333_linear_fm](https://github.com/cubing/icons/assets/53250435/a19db358-5c34-4b69-b602-7e905fcb0783)
