### PR TITLE
Fix `make lint` and `make format`, enforce `biome check` in Nix/CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 /result
 /www
 
+# This really ought to live in `.git/info/exclude`, but `biome` doesn't understand that file:
+# https://github.com/biomejs/biome/issues/4822
+/.direnv
+
 node_modules/
 
 # Courtesy of https://github.com/shinnn/gulp-gh-pages

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,17 @@
+{
+  "vcs": {
+    "enabled": true,
+    "useIgnoreFile": true,
+    "clientKind": "git"
+  },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,28 +1,28 @@
-var del = require("del");
-var gulp = require("gulp");
-var path = require("path");
-var jimp = require("gulp-jimp");
-var through = require("through2");
-var rename = require("gulp-rename");
-var svg2png = require("gulp-svg2png");
-var iconfont = require("gulp-iconfont");
-var bufferstreams = require("bufferstreams");
-var child_process = require("child_process");
-var consolidate = require("gulp-consolidate");
+const del = require("del");
+const gulp = require("gulp");
+const path = require("node:path");
+const jimp = require("gulp-jimp");
+const through = require("through2");
+const rename = require("gulp-rename");
+const svg2png = require("gulp-svg2png");
+const iconfont = require("gulp-iconfont");
+const bufferstreams = require("bufferstreams");
+const child_process = require("node:child_process");
+const consolidate = require("gulp-consolidate");
 
-var FONT_NAME = "cubing-icons";
-var SVG_FILES = "svgs/*/*.svg";
-var STATIC_FILES = "static/*/*";
-var TEMPLATE_FILES = "templates/*.lodash";
-var SRC_FILES = [SVG_FILES, TEMPLATE_FILES];
+const FONT_NAME = "cubing-icons";
+const SVG_FILES = "svgs/*/*.svg";
+const STATIC_FILES = "static/*/*";
+const TEMPLATE_FILES = "templates/*.lodash";
+const SRC_FILES = [SVG_FILES, TEMPLATE_FILES];
 
-var runTimestamp = Math.round(Date.now() / 1000);
+const runTimestamp = Math.round(Date.now() / 1000);
 
 const defaultTask = gulp.parallel(copySvgs, copyStaticFiles, css);
 export default defaultTask;
 
 export function css() {
-  var fontCss = fontCssPipe();
+  const fontCss = fontCssPipe();
   return (
     gulp
       .src(SVG_FILES)
@@ -35,7 +35,7 @@ export function css() {
       // svg2png looks for files on the filesystem by name, so we cannot
       // rename until after svg2png. We should really fix this bug in svg2png.
       .pipe(
-        through.obj(function (file, enc, next) {
+        through.obj((file, enc, next) => {
           file.path = path.join(
             path.dirname(file.path),
             file.relative.replace("/", "-"),
@@ -63,7 +63,7 @@ export function css() {
           fontHeight: 1000,
         }),
       )
-      .on("glyphs", function (glyphs, options) {
+      .on("glyphs", (glyphs, options) => {
         // Stash glyphs so we can generate the CSS at the end.
         fontCss.glyphs = glyphs;
 
@@ -99,12 +99,12 @@ export function clean() {
 }
 
 function fontCssPipe() {
-  var fontFiles = [];
+  const fontFiles = [];
   return through.obj(
-    function (file, enc, cb) {
+    (file, enc, cb) => {
       file.contents
         .pipe(
-          new bufferstreams(function (err, buf, cb) {
+          new bufferstreams((err, buf, cb) => {
             if (err) {
               throw err;
             }
@@ -117,11 +117,9 @@ function fontCssPipe() {
     },
     function (cb) {
       // Modified from https://www.npmjs.com/package/gulp-iconfont
-      var fontUrls = {
-        woff:
-          "data:application/x-font-woff;charset=utf-8;base64," + fontFiles.woff,
-        ttf:
-          "data:application/x-font-ttf;charset=utf-8;base64," + fontFiles.ttf,
+      const fontUrls = {
+        woff: `data:application/x-font-woff;charset=utf-8;base64,${fontFiles.woff}`,
+        ttf: `data:application/x-font-ttf;charset=utf-8;base64,${fontFiles.ttf}`,
       };
       gulp
         .src("templates/cubing-icons.css.lodash")
@@ -141,8 +139,8 @@ function fontCssPipe() {
 }
 
 function bmp2svg() {
-  return through.obj(function (file, enc, next) {
-    var potraceProcess = child_process.spawn(
+  return through.obj((file, enc, next) => {
+    const potraceProcess = child_process.spawn(
       "potrace",
       ["-o", "-", "-b", "svg"],
       {
@@ -154,14 +152,14 @@ function bmp2svg() {
     potraceProcess.stdin.end();
 
     // TODO - there must be some way of avoiding this...
-    var buffer = new Buffer.alloc(0);
-    potraceProcess.stdout.on("data", function (data) {
+    let buffer = new Buffer.alloc(0);
+    potraceProcess.stdout.on("data", (data) => {
       buffer = Buffer.concat([buffer, data]);
     });
 
-    potraceProcess.once("close", function (code) {
+    potraceProcess.once("close", (code) => {
       if (code !== 0) {
-        next(new Error("potrace exited with code " + code, null));
+        next(new Error(`potrace exited with code ${code}`, null));
       } else {
         file.extname = ".svg";
         file.contents = buffer;

--- a/nix/formatting.nix
+++ b/nix/formatting.nix
@@ -2,14 +2,29 @@
 {
   imports = [ inputs.treefmt-nix.flakeModule ];
 
-  perSystem.treefmt = {
-    flakeCheck = true;
-    programs = {
-      nixfmt.enable = true;
-      biome = {
-        enable = true;
-        settings.formatter.indentStyle = "space";
+  perSystem =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    {
+      treefmt = {
+        flakeCheck = true;
+        programs = {
+          nixfmt.enable = true;
+          biome.enable = true;
+        };
+        settings.formatter = {
+          "biome-check" = {
+            command = lib.getExe pkgs.biome;
+            options = [
+              "check"
+            ];
+            inherit (config.treefmt.programs.biome) includes;
+          };
+        };
       };
     };
-  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/core": "^7.10.5",
         "@babel/preset-env": "^7.10.4",
         "@babel/register": "^7.10.5",
+        "@biomejs/biome": "^1.1.2",
         "bufferstreams": "^3.0.0",
         "del": "^5.1.0",
         "gulp": "^4.0.2",
@@ -1245,6 +1246,170 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -9890,6 +10055,78 @@
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "requires": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "dev": true,
+      "optional": true
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@babel/core": "^7.10.5",
     "@babel/preset-env": "^7.10.4",
     "@babel/register": "^7.10.5",
+    "@biomejs/biome": "^1.1.2",
     "bufferstreams": "^3.0.0",
     "del": "^5.1.0",
     "gulp": "^4.0.2",
@@ -22,7 +23,9 @@
     "watch": "gulp watch",
     "dev": "npm run watch",
     "version": "npm run build",
-    "postversion": "git push --follow-tags git@github.com:cubing/icons.git HEAD:main && npm publish"
+    "postversion": "git push --follow-tags git@github.com:cubing/icons.git HEAD:main && npm publish",
+    "lint": "npx @biomejs/biome check .",
+    "format": "npx @biomejs/biome format --write ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `make` commands were broken because we didn't have `biome` listed as
a dependency, and we didn't have a `biome.json` file.

There's unfortunately still some inconsistency here in that `nix fmt`
and `nix flake check` are going to use whatever version of biome is
present in `nixpkgs`, whereas `make lint` is going to use the version in
our `package-lock.json`. We could make this consistent, but I'm
inclined to wait for it to be a problem.
