### PR TITLE
v2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cubing/icons",
-  "version": "2.1.0-pre.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cubing/icons",
-      "version": "2.1.0-pre.2",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cubing/icons",
-  "version": "2.1.0-pre.2",
+  "version": "2.1.0",
   "author": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release notes:

- Overhaul the build system. The usage is still the same and icon sizing and layout should be compatible, but:
  - Fonts are no longer inlined into the CSS, allowing for loading of the most efficient format available.
  - Exports are now specifed by the package:
    - `@cubing/icons/css`: the new recommended entry point for CSS.
    - `@cubing/icons/ts`: data about available icons in TypeScript.