### PR TITLE
Move from magic-nix-cache-action to cachix

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix flake check
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v16
+        with:
+          name: cubing
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix run --inputs-from . nixpkgs#nix-fast-build -- --skip-cached --no-nom

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -13,8 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v16
+        with:
+          name: cubing
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build .#web --out-link ./dist/web/icons.cubing.net
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Unfortunately, Magic Nix Cache is going away:
https://determinate.systems/posts/magic-nix-cache-free-tier-eol/

nix.dev recommends cachix, and I now know the person who runs it: https://nix.dev/guides/recipes/continuous-integration-github-actions.html. I've set up an organization for us.