### PR TITLE
Add `/.direnv` and `/.envrc` to our `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 # See the `bun.lock` target in `Makefile` for more details.
 /bun.lock
 /bun.lockb
+
+# These would be more appropriate in individual user's `.git/info/exclude`
+# files, but must be here to work around <https://github.com/biomejs/biome/issues/4822>.
+/.direnv
+/.envrc


### PR DESCRIPTION
This is a workaround for `biome`s unfortunate decision to (fail to)
reimplement git's semantics themselves.

This addresses <https://github.com/cubing/icons/issues/189>. Basically,
biome would follow my `/.direnv` symlink and find a bunch of Javascript
code (our various third party dependencies in the `/nix/store`) it was
unhappy with.