### PR TITLE
[package.json] Update the package description to match the repo description.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"homepage": "https://github.com/cubing/icons#readme",
 	"license": "MIT",
 	"type": "module",
-	"description": "Cubing Icons and Fonts",
+	"description": "Icons for WCA events, unofficial events, and competition-related concepts.",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/cubing/icons.git"


### PR DESCRIPTION
The repo description is more detailed and accurate to the current state of the project.

In particular, this removes the mention of fonts. We now have an explicit list of exports, which does not include the font files. And in any case, I don't think it's currently practical or even desirable to encourage usage of the published fonts without the associated CSS class mappings. (Note that this argument doesn't quite apply to the SVGs, which are maintained in-tree.)