### PR TITLE
[CI.yaml] Pin the `bun` version to `1.2.19` in CI.

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,7 +11,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.19"
       - run: make setup
       - run: make build-lib-js
       - run: make build-lib-types
@@ -25,7 +27,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.19"
       - run: make setup
       - run: make lint-ts-biome
       - run: make lint-ts-tsc

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
 			"default": "./ts/index.ts"
 		}
 	},
+	"engines": {
+		"node": ">=22.3.0",
+		"bun": ">=1.2.19"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.1.4",
 		"@cubing/dev-config": "^0.3.6",


### PR DESCRIPTION
Also set `"engines"` in `package.json`, although `bun` doesn't check this yet: https://github.com/oven-sh/bun/issues/5846