### PR TITLE
Optimize target dependencies and exercise them in CI.

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,9 +13,9 @@ jobs:
           node-version: 22
       - uses: oven-sh/setup-bun@v1
       - run: make setup
-      - run: make build-lib-js
-      - run: make build-lib-types
-      - run: make build-web
+      - run: make clean build-lib-js
+      - run: make clean build-lib-types
+      - run: make clean build-web
 
   test:
     runs-on: ubuntu-latest
@@ -27,6 +27,6 @@ jobs:
           node-version: 22
       - uses: oven-sh/setup-bun@v1
       - run: make setup
-      - run: make lint-ts-biome
-      - run: make lint-ts-tsc
-      - run: make bun-test
+      - run: make clean lint-ts-biome
+      - run: make clean lint-ts-tsc
+      - run: make clean bun-test

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build-lib-types: build-lib-js
 	bun x tsc --project ./tsconfig.build.json
 
 .PHONY: build-web
-build-web: setup build-lib
+build-web: setup build-lib-js
 	bun run script/build-web.ts
 
 .PHONY: setup
@@ -39,12 +39,11 @@ bun-test:
 lint: setup lint-ts-biome lint-ts-tsc
 
 .PHONY: lint-ts-biome
-lint-ts-biome: build-lib
+lint-ts-biome: build-lib-js
 	bun x @biomejs/biome check
 
 .PHONY: lint-ts-tsc
-# `./script/build-web.ts` imports the list of icons from the build lib, so we need to `build-lib` before we can lint.
-lint-ts-tsc: build-lib
+lint-ts-tsc: build-lib-types
 	bun x tsc --noEmit --project .
 
 .PHONY: format

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build-lib-js: setup
 
 .PHONY: build-lib-types
 build-lib-types: build-lib-js
-	bun x tsc --project ./tsconfig.build.json
+	bun x tsc --project ./tsconfig.build.jsonc
 
 .PHONY: build-web
 build-web: setup build-lib-js

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "schema": "https://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist/lib/@cubing/icons/js"
-  },
-  "include": ["./src/js/index.ts"]
-}

--- a/tsconfig.build.jsonc
+++ b/tsconfig.build.jsonc
@@ -1,0 +1,13 @@
+{
+  "schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/lib/@cubing/icons/js",
+    // The types are checked by the main `tsconfig.json`. We skip the check here
+    // to allow faster building of the types files, which we need to do
+    // separately before we can lint the codebase.
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["./src/js/index.ts"]
+}


### PR DESCRIPTION
TypeScript is sloooooooow. But we can avoid invoking it when we know that targets don't depend on it.

On my computer (M1 Max), this takes:

- `make build` from 2.2 seconds to 0.95 seconds.
- `make lint` from 3.5 seconds to 2.3 seconds