### PR TITLE
Test the the exports of the built package.

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -29,4 +29,5 @@ jobs:
       - run: make setup
       - run: make lint-ts-biome
       - run: make lint-ts-tsc
-      - run: make bun-test
+      - run: make test-bun
+      - run: make test-exports

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,20 @@ ifndef NIX_BUILD_TOP
 endif
 
 .PHONY: test
-test: lint bun-test
+test: test-bun test-exports lint
 
-.PHONY: bun-test
-bun-test:
+.PHONY: test-bun
+test-bun:
 	bun test
+
+.PHONY: test-exports
+test-exports: build-lib-js
+	node -- 'test/exports/test-legacy-export.js'
+	bun run -- 'test/exports/test-legacy-export.js'
+	bun run -- 'test/exports/test-legacy-export.ts'
+	node -- 'test/exports/test-package-export.js'
+	bun run -- 'test/exports/test-package-export.js'
+	bun run -- 'test/exports/test-package-export.ts'
 
 .PHONY: lint
 lint: setup lint-ts-biome lint-ts-tsc
@@ -46,6 +55,7 @@ lint-ts-biome: build-lib
 # `./script/build-web.ts` imports the list of icons from the build lib, so we need to `build-lib` before we can lint.
 lint-ts-tsc: build-lib
 	bun x tsc --noEmit --project .
+	bun x tsc --noEmit --project ./test/exports/tsconfig.json
 
 .PHONY: format
 format: setup

--- a/test/exports/test-legacy-export.js
+++ b/test/exports/test-legacy-export.js
@@ -1,0 +1,5 @@
+import { default as assert } from "node:assert";
+import { CubingIcons } from "../../js/index.js";
+
+assert(typeof CubingIcons === "object");
+console.log("OK");

--- a/test/exports/test-legacy-export.ts
+++ b/test/exports/test-legacy-export.ts
@@ -1,0 +1,16 @@
+import { default as assert } from "node:assert";
+
+let capturedConsoleErrorMessage: string | undefined;
+console.error = (s) => {
+  capturedConsoleErrorMessage = s;
+};
+
+// This must be a dynamic import to avoid being hoisted above the `console.error` modification.
+const { CubingIcons } = await import("../../ts");
+
+assert(typeof CubingIcons === "object");
+assert.equal(
+  capturedConsoleErrorMessage,
+  "Using `@cubing/icons/ts` is deprecated. Please use `@cubing/icons/js` for the same functionality.",
+);
+console.log("OK");

--- a/test/exports/test-package-export.js
+++ b/test/exports/test-package-export.js
@@ -1,0 +1,5 @@
+import { default as assert } from "node:assert";
+import { CubingIcons } from "@cubing/icons/js";
+
+assert(typeof CubingIcons === "object");
+console.log("OK");

--- a/test/exports/test-package-export.ts
+++ b/test/exports/test-package-export.ts
@@ -1,0 +1,16 @@
+import { default as assert } from "node:assert";
+
+let capturedConsoleErrorMessage: string | undefined;
+console.error = (s) => {
+  capturedConsoleErrorMessage = s;
+};
+
+// This must be a dynamic import to avoid being hoisted above the `console.error` modification.
+const { CubingIcons } = await import("@cubing/icons/ts");
+
+assert(typeof CubingIcons === "object");
+assert.equal(
+  capturedConsoleErrorMessage,
+  "Using `@cubing/icons/ts` is deprecated. Please use `@cubing/icons/js` for the same functionality.",
+);
+console.log("OK");

--- a/test/exports/tsconfig.json
+++ b/test/exports/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../node_modules/@cubing/dev-config/ts/es2022-types/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../../",
+    "paths": {
+      "@cubing/icons": ["../"]
+    }
+  },
+  "include": ["**/*"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,8 @@
   "schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist/lib/@cubing/icons/js"
+    "rootDir": "./src/js/",
+    "outDir": "./dist/lib/@cubing/icons/js/"
   },
   "include": ["./src/js/index.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "./node_modules/@cubing/dev-config/ts/es2022-types/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
   "include": ["**/*"],
-  "exclude": ["./.temp/", "./dist/"]
+  "exclude": ["./.temp/", "./dist/", "./test/exports/"]
 }


### PR DESCRIPTION
This gives us more confidence that they can be imported from the published package by runtimes/bundlers.